### PR TITLE
Bugfix structs.go

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -88,7 +88,7 @@ type User struct {
 	Relation        int    `json:"relation"`
 	Hidden          int    `json:"hidden"`
 	Closed          int    `json:"is_closed"`
-	CanAccessClosed int    `json:"can_access_closed"`
+	CanAccessClosed bool    `json:"can_access_closed"`
 	Deactivated     string `json:"deactivated"`
 	IsAdmin         bool   `json:"is_admin"`
 	IsOwner         bool   `json:"is_owner"`


### PR DESCRIPTION
Сhanged the field type of the User structure to the same as in the documentation, since it did not match and part of the functionality did not work.

![image](https://github.com/nikepan/govkbot/assets/76521999/ed512c85-04bd-47e2-b3bb-67a72551eea9)

![изображение_2023-09-01_033250406](https://github.com/nikepan/govkbot/assets/76521999/42db7812-8fb9-4e92-8041-66a6edfb850f)


![image](https://github.com/nikepan/govkbot/assets/76521999/677b5db4-f729-408d-a8b6-2f5a346551ee)

![image](https://github.com/nikepan/govkbot/assets/76521999/3051e7ae-70e8-4763-96fc-5d883ea383c5)
